### PR TITLE
Fix parameter check bug.

### DIFF
--- a/src/HesaiLidar_General_SDK/src/tcp_command_client.c
+++ b/src/HesaiLidar_General_SDK/src/tcp_command_client.c
@@ -140,7 +140,7 @@ static int TcpCommand_buildHeader(char* buffer, TC_Command* cmd) {
 static PTC_ErrCode tcpCommandClient_SendCmd(TcpCommandClient* client,
                                             TC_Command* cmd) {
   printf("tcpCommandClient_SendCmd\n");
-  if (!client && !cmd) {
+  if (!client || !cmd) {
     printf("Bad Parameter\n");
     return PTC_ERROR_BAD_PARAMETER;
   }


### PR DESCRIPTION
Neither the parameter `client' and `cmd' should be NULL here. Any of these 2 parameters being NULL  will result in crash.