### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,10 @@ target_link_libraries(hesai_lidar_node
 rosidl_target_interfaces(hesai_lidar_node  ${PROJECT_NAME} "rosidl_typesupport_cpp")
 install(TARGETS hesai_lidar_node
   DESTINATION lib/${PROJECT_NAME})
-
+  
+install(TARGETS PandarGeneralSDK PandarGeneral
+  DESTINATION lib)
+  
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME})
 


### PR DESCRIPTION
This MR is related to [colcon build --symlink-install](https://github.com/HesaiTechnology/HesaiLidar_General_ROS/blob/55a736ef4210451c5f454fad8d78705d6d11bfe0/README.md?plain=1#L36).
The --symlink-install option is not required for every users.  
It is not able to build if someone don't use --symlink-install because `colcon` will not copy libraries like  `PandarGeneralSDK` and `PandarGeneral`. 